### PR TITLE
[openbas] upgrade major dependencies (2024-09-01)

### DIFF
--- a/charts/openbas/Chart.yaml
+++ b/charts/openbas/Chart.yaml
@@ -22,14 +22,14 @@ keywords:
   - analysis
 dependencies:
   - name: minio
-    version: 14.7.1
+    version: 14.7.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: postgresql
-    version: 15.5.24
+    version: 15.5.27
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: rabbitmq
-    version: 14.6.6
+    version: 14.6.9
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled

--- a/charts/openbas/README.md
+++ b/charts/openbas/README.md
@@ -16,9 +16,9 @@ A Helm chart to deploy Open Breach and Attack Simulation platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.1 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.24 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.6 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.4 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.27 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.9 |
 
 ## Add repository
 


### PR DESCRIPTION
rabbitmq
--------

* **Current**: `14.6.6`
* **Upgrade**: `14.6.9`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/14.6.9

postgresql
----------

* **Current**: `15.5.24`
* **Upgrade**: `15.5.27`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/postgresql/15.5.27

minio
-----

* **Current**: `14.7.1`
* **Upgrade**: `14.7.4`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.4

