### PR TITLE
[openbas] upgrade major dependencies (2024-11-01)

### DIFF
--- a/charts/openbas/Chart.yaml
+++ b/charts/openbas/Chart.yaml
@@ -22,14 +22,14 @@ keywords:
   - analysis
 dependencies:
   - name: minio
-    version: 14.8.0
+    version: 14.8.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: postgresql
-    version: 15.5.38
+    version: 16.1.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: rabbitmq
-    version: 15.0.3
+    version: 15.0.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled

--- a/charts/openbas/README.md
+++ b/charts/openbas/README.md
@@ -16,9 +16,9 @@ A Helm chart to deploy Open Breach and Attack Simulation platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.8.0 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.38 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.3 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.8.1 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.1.0 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.5 |
 
 ## Add repository
 


### PR DESCRIPTION
postgresql
----------

* **Current**: `15.5.38`
* **Upgrade**: `16.1.0`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/postgresql/16.1.0

minio
-----

* **Current**: `14.8.0`
* **Upgrade**: `14.8.1`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.8.1

rabbitmq
--------

* **Current**: `15.0.3`
* **Upgrade**: `15.0.5`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/15.0.5

