### PR TITLE
fix: [openaev] new release: 2.260710.0

### DIFF
--- a/charts/openaev/Chart.yaml
+++ b/charts/openaev/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/devops-ia/helm-openaev
   - https://github.com/OpenAEV-Platform/openaev
 version: 1.0.0
-appVersion: 2.260708.1
+appVersion: 2.260710.0
 home: https://www.filigran.io/en/solutions/products/openaev/
 keywords:
   - openaev


### PR DESCRIPTION
OpenAEV version:
- :information_source: Current: `2.260708.1`
- :up: Upgrade: `2.260710.0`

Changelog: https://github.com/OpenAEV-Platform/openaev/releases/tag/2.260710.0